### PR TITLE
Disable -fast for gameversion 1.2

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1126,6 +1126,12 @@ static void InitGameVersion(void)
         deathmatch = 1;
     }
     
+    // -fast was not an option until Doom v1.4
+    if (gameversion <= exe_doom_1_2)
+    {
+        fastparm = 0;
+    }
+
     // The original exe does not support retail - 4th episode not supported
 
     if (gameversion < exe_ultimate && gamemode == retail)


### PR DESCRIPTION
The first appearance of the "-fast" string in DOOM.EXE is in the v1.4 beta leak (1994-04-08). Vanilla v1.2 ignores the "-fast" switch.